### PR TITLE
Improve the code for setting the 1V8-pin, including get-function

### DIFF
--- a/CHIP_IO/Utilities.py
+++ b/CHIP_IO/Utilities.py
@@ -26,13 +26,36 @@
 
 import subprocess
 
+# Set the 1.8V-pin on the CHIP U13-header to given voltage
+# Return False on error
+def set_1v8_pin_voltage(voltage):
+    if not isinstance(voltage, int) and not isinstance(voltage, float):
+        return False
+    if voltage < 1.8 or voltage > 3.3:
+        return False
+    voltage=round((voltage - 1.8) / 0.1) << 4
+    if subprocess.call(["/usr/sbin/i2cset", "-f", "-y" ,"0", "0x34", "0x90", "0x03"]):
+        return False
+    if subprocess.call(["/usr/sbin/i2cset", "-f", "-y", "0", "0x34", "0x91", str(voltage)]):
+        return False
+    return True
+
+# Get the voltage the 1.8V-pin on the CHIP U13-header has been configured as
+# Return False on error
+def get_1v8_pin_voltage():
+    p=subprocess.Popen(["/usr/sbin/i2cget", "-f", "-y", "0", "0x34", "0x90"], stdout=subprocess.PIPE)
+    output=p.communicate()[0].decode("utf-8").strip()
+    #Not configured as an output
+    if output != "0x03":
+        return False
+    p=subprocess.Popen(["/usr/sbin/i2cget", "-f", "-y", "0", "0x34", "0x91"], stdout=subprocess.PIPE)
+    output=p.communicate()[0].decode("utf-8").strip()
+    voltage=round((int(output, 16) >> 4) * 0.1 + 1.8, 1)
+    return voltage
+
 # Enable 1.8V Pin on CHIP U13 Header
 def enable_1v8_pin():
-    # CANNOT USE I2C LIB AS WE NEED TO FORCE THE COMMAND DUE TO THE KERNEL OWNING THE DEVICE
-    # First we have to write 0x00 to AXP-209 Register 0x91
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x91 0x00', shell=True)
-    # Then we have to write 0x03 to AXP-209 Register 0x90
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x90 0x03', shell=True)
+    set_1v8_pin_voltage(1.8)
 
 # Disable 1.8V Pin on CHIP U13 Header
 def disable_1v8_pin():
@@ -41,29 +64,3 @@ def disable_1v8_pin():
     subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x91 0x05', shell=True)
     # Then we have to write 0x07 to AXP-209 Register 0x90
     subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x90 0x07', shell=True)
-
-# Change 1.8V Pin on CHIP U13 Header to 2.0V
-def change_1v8_pin_to_2v0():
-    # CANNOT USE I2C LIB AS WE NEED TO FORCE THE COMMAND DUE TO THE KERNEL OWNING THE DEVICE
-    # First we have to write 0x20 to AXP-209 Register 0x91
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x91 0x20', shell=True)
-    # Then we have to write 0x03 to AXP-209 Register 0x90
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x90 0x03', shell=True)
-
-# Change 1.8V Pin on CHIP U13 Header to 2.6V
-def change_1v8_pin_to_2v6():
-    # CANNOT USE I2C LIB AS WE NEED TO FORCE THE COMMAND DUE TO THE KERNEL OWNING THE DEVICE
-    # First we have to write 0x80 to AXP-209 Register 0x91
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x91 0x80', shell=True)
-    # Then we have to write 0x03 to AXP-209 Register 0x90
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x90 0x03', shell=True)
-
-# Change 1.8V Pin on CHIP U13 Header to 3.3V
-def change_1v8_pin_to_3v3():
-    # CANNOT USE I2C LIB AS WE NEED TO FORCE THE COMMAND DUE TO THE KERNEL OWNING THE DEVICE
-    # First we have to write 0xF0 to AXP-209 Register 0x91
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x91 0xF0', shell=True)
-    # Then we have to write 0x03 to AXP-209 Register 0x90
-    subprocess.call('/usr/sbin/i2cset -f -y 0 0x34 0x90 0x03', shell=True)
-
-

--- a/README.rst
+++ b/README.rst
@@ -322,13 +322,15 @@ To use the utilities, here is sample code::
     # Enable 1.8V Output
     UT.enable_1v8_pin()
     # Set 2.0V Output
-    UT.change_1v8_pin_to_2v0()
+    UT.set_1v8_pin_voltage(2.0)
     # Set 2.6V Output
-    UT.change_1v8_pin_to_2v6()
+    UT.set_1v8_pin_voltage(2.6)
     # Set 3.3V Output
-    UT.change_1v8_pin_to_3v3()
+    UT.set_1v8_pin_voltage(3.3)
     # Disable 1.8V Output
     UT.disable_1v8_pin()
+    # Get currently-configured voltage (returns False if the pin is not enabled as output)
+    UT.get_1v8_pin_voltage()
 
 **Running tests**
 


### PR DESCRIPTION
It's crude and ugly to make multiple functions to set the pin at different voltage-levels, when you can just write a single function that accepts the desired voltage as a parameter. Also, I included a function to query the currently-configured voltage.