### PR TITLE
Add 'TARGET_DIR' prefix env var to builder.py

### DIFF
--- a/overlays/builder.py
+++ b/overlays/builder.py
@@ -2,6 +2,7 @@ from subprocess import call
 import os
 import shutil
 import glob
+import sys
 
 def compile():
     print("Compiling DTS Files")
@@ -10,15 +11,16 @@ def compile():
     call(["dtc", "-O", "dtb", "-o", "overlays/chip-pwm0.dtbo", "-b", "o", "-@", "overlays/chip-pwm0.dts"])
 
 def copy():
+    target_dir = os.environ.get('TARGET_DIR', '')
+    overlay_path = target_dir + "/lib/firmware/chip_io"
     print("Checking for DTBO Install Path")
-    if not os.path.exists("/lib/firmware/chip_io/"):
-        print("Path not found, creating /lib/firmware/chip_io/")
-        os.makedirs("/lib/firmware/chip_io/")
+    if not os.path.exists(overlay_path):
+        print("Path not found, creating "+overlay_path)
+        os.makedirs(overlay_path)
     print("Removing old DTBO files (if applicable)")
-    for fl in glob.glob("/lib/firmware/chip_io/chip-*-.dtbo"):
+    for fl in glob.glob(overlay_path+"/chip-*-.dtbo"):
         os.remove(fl)
-    print("Moving DTBO files to /lib/firmware/chip_io/")
-    shutil.move("overlays/chip-spi2.dtbo", "/lib/firmware/chip_io/chip-spi2.dtbo")
-    shutil.move("overlays/chip-i2c1.dtbo", "/lib/firmware/chip_io/chip-i2c1.dtbo")
-    shutil.move("overlays/chip-pwm0.dtbo", "/lib/firmware/chip_io/chip-pwm0.dtbo")
-
+    print("Moving DTBO files to "+overlay_path)
+    shutil.move("overlays/chip-spi2.dtbo", overlay_path+"/chip-spi2.dtbo")
+    shutil.move("overlays/chip-i2c1.dtbo", overlay_path+"/chip-i2c1.dtbo")
+    shutil.move("overlays/chip-pwm0.dtbo", overlay_path+"/chip-pwm0.dtbo")


### PR DESCRIPTION
This allows CHIP_IO to build and install successfully in buildroot.