### PR TITLE
Updated rpigpiomodule to chipgpiomodule so python3 compile works

### DIFF
--- a/source/py_gpio.c
+++ b/source/py_gpio.c
@@ -861,7 +861,7 @@ PyMODINIT_FUNC initGPIO(void)
    clear_error_msg();
 
 #if PY_MAJOR_VERSION > 2
-   if ((module = PyModule_Create(&rpigpiomodule)) == NULL)
+   if ((module = PyModule_Create(&chipgpiomodule)) == NULL)
       return NULL;
 #else
    if ((module = Py_InitModule3("GPIO", gpio_methods, moduledocstring)) == NULL)


### PR DESCRIPTION
Updated line 864 of py_gpio.c to fix an issue with rpigpiomodule not being declared when compiling for python3, updating it to fix issue #51 