### PR TITLE
Extern integer definitions in the header file

### DIFF
--- a/source/common.h
+++ b/source/common.h
@@ -86,9 +86,9 @@ typedef struct dyn_int_array_s dyn_int_array_t;
 
 #define FILENAME_BUFFER_SIZE 128
 
-int setup_error;
-int module_setup;
-int DEBUG;
+extern int setup_error;
+extern int module_setup;
+extern int DEBUG;
 
 int get_xio_base(void);
 int is_this_chippro(void);


### PR DESCRIPTION
Integers are defined in both the .c and the common.h file leading to linking
issues with the library when used externally and potentially causing issues
within the code as well.