### PR TITLE
add 1s delay in set_direction to allow udev to set permissions

### DIFF
--- a/source/event_gpio.c
+++ b/source/event_gpio.c
@@ -383,11 +383,18 @@ int gpio_set_direction(int gpio, unsigned int in_flag)
     char filename[MAX_FILENAME];  filename[0] = '\0';
 
     snprintf(filename, sizeof(filename), "/sys/class/gpio/gpio%d/direction", gpio); BUF2SMALL(filename);
+
     if ((fd = open(filename, O_WRONLY)) < 0) {
-        char err[256];
-        snprintf(err, sizeof(err), "gpio_set_direction: could not open '%s' (%s)", filename, strerror(errno));
-        add_error_msg(err);
-        return -1;
+        // if called as non-root, udev may need time to adjust file
+        // permissions after setting up gpio
+        sleep(1);
+
+        if ((fd = open(filename, O_WRONLY)) < 0) {
+            char err[256];
+            snprintf(err, sizeof(err), "gpio_set_direction: could not open '%s' (%s)", filename, strerror(errno));
+            add_error_msg(err);
+            return -1;
+        }
     }
 
     char direction[16];


### PR DESCRIPTION
When using GPIO as non-root user, udev scripts have to update permissions when a GPIO pin is exported.
This udev update may take a few miliseconds and can be too late for gpio_set_direction.
Change adds a delay of 1 second if gpio sys file cannot be opened and retries access